### PR TITLE
Software Install Only

### DIFF
--- a/tasks/install-wls.yml
+++ b/tasks/install-wls.yml
@@ -183,3 +183,4 @@
         state: "started"
 
   become: True
+  when: node_manager.install


### PR DESCRIPTION
Trying to speed up ci/cd testing of weblogic creation and patching scripts, so trying to create a box with just weblogic installed and without any domain or node manager.

Without this patch the installation fails, because wls_server is missing and is required by the nodemanager_server.j2 template.

```ruby
  roles:
    - role: lean_delivery.weblogic
      wls_version: "12.1.3.0.0"
      transport: "local"
      transport_local: "/vagrant/wls1213_dev_update3.zip"
      install_type: "WebLogic Server"
      domain:
        create: False
      node_manager:
        install: False
```

Packer 1.5.5
Vagrant 2.2.7
CentOS Linux release 7.7.1908 (Core)
Ansible 2.9.6
WebLogic 12.1.3.0.0