### PR TITLE
Readme update including how to use generic jar installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Role Variables
 
   - `wls_version` - Oracle WebLogic version
 
-#### Set WebLogic version as it's defined in official Oracle Documentation
+    __Set WebLogic version as it's defined in official Oracle Documentation__
 
   - `wls_path` - where WebLogic should be installed
     default: `/opt/weblogic`

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Role Variables
       - `web` - fetch artifact from custom web uri
       - `local` - local artifact
 
+    __A generic jar installer is avalaible for some releases like fmw_12.1.3.0.0_wls.jar. To use that installer, just wrap the jar into a zip and use that zip__
+
   - `transport_web` - URI for http/https artifact  e.g. "http://my-storage.example.com/V886423-01.zip"
   - `transport_local` - path for local artifact e.g. "/tmp/V886423-01.zip"
 


### PR DESCRIPTION
1) Note about wls_version should probably just be bold and not a new header level3
2) Note about using generic jar installer

Tested using fmw_12.1.3.0.0_wls.jar