### PR TITLE
Create nodemanager.domains if needed

### DIFF
--- a/tasks/install-wls.yml
+++ b/tasks/install-wls.yml
@@ -190,6 +190,20 @@
         mode: u=rwx,g=rx,o=
       when: wls_nodemanager_dir.stat.exists == False
 
+    - name: Check if WebLogic Node Manager file nodemanager.domains exists
+      stat:
+        path: "{{ wls_path }}/oracle_common/common/nodemanager/nodemanager.domains"
+      register: wls_nodemanager_domains_file
+
+    - name: Create WebLogic Node Manager file nodemanager.domains if needed
+      file:
+        path: "{{ wls_path }}/oracle_common/common/nodemanager/nodemanager.domains"
+        state: touch
+        owner: "{{ wls_user }}"
+        group: "{{ wls_group }}"
+        mode: u=rw,g=r,o=
+      when: wls_nodemanager_domains_file.stat.exists == False
+
     - name: "Start Node Manager"
       service:
         name: "{{ node_manager.service }}"

--- a/tasks/install-wls.yml
+++ b/tasks/install-wls.yml
@@ -176,6 +176,20 @@
         daemon_reload: True
       when: ansible_facts.service_mgr == "systemd"
 
+    - name: Check if WebLogic Node Manager dir nodemanager exists
+      stat:
+        path: "{{ wls_path }}/oracle_common/common/nodemanager"
+      register: wls_nodemanager_dir
+
+    - name: Create WebLogic Node Manager dir nodemanager if needed
+      file:
+        path: "{{ wls_path }}/oracle_common/common/nodemanager"
+        state: directory
+        owner: "{{ wls_user }}"
+        group: "{{ wls_group }}"
+        mode: u=rwx,g=rx,o=
+      when: wls_nodemanager_dir.stat.exists == False
+
     - name: "Start Node Manager"
       service:
         name: "{{ node_manager.service }}"


### PR DESCRIPTION
I'm setting up a learning domain for weblogic and discovered nodemanager.domains is not created out of the box so needed to create it myself. So adding into nm section of setup so will always be their.